### PR TITLE
Add Debug mode

### DIFF
--- a/wotbr2jlib/dictpackers_24.py
+++ b/wotbr2jlib/dictpackers_24.py
@@ -1,6 +1,8 @@
 # Embedded file name: scripts/common/DictPackers.py
 import copy
 # from debug_utils import *
+import logging
+import traceback
 from binascii import crc32
 
 def roundToInt(val):
@@ -103,9 +105,16 @@ class DictPacker(object):
         if (len(dataList) == 0):
             return
         elif dataList[0] != self._checksum:
-            import traceback
-            traceback.print_stack()
-            raise Exception('Expected checksum of ' + str(self._checksum) + ' but got ' + str(dataList[0]))
+            if logging.getLogger().isEnabledFor(logging.DEBUG):
+                logging.debug('Expected checksum of ' + str(self._checksum) + ' not ' + str(dataList[0]))
+                try:
+                    # Get a stack trace so it's easy to find which checksum is failing
+                    raise Exception()
+                except Exception as e:
+                    # Only the location of the call to this method is needed to determine which checksum is failing
+                    key_trace = traceback.extract_stack(limit=2)[0]
+                    logging.debug('\tat "' + key_trace[0] + '", line ' + str(key_trace[1]) + ', in ' + key_trace[2])
+
             return
         else:
             for index, meta in enumerate(self._metaData):

--- a/wotbr2jlib/wotbr2j.py
+++ b/wotbr2jlib/wotbr2j.py
@@ -57,6 +57,7 @@ def usage():
     print 'Options:'
     print '-f Formats the JSON to be more human readable'
     print '-s Server Mode, disable writing of timestamp, enable logging'
+    print '-d Enable Debug Output'
 
 
 def main():
@@ -83,6 +84,9 @@ def main():
             option_server = 1
             logger = logging.getLogger()
             logger.addHandler(logging.FileHandler(filename='wotbr2jlib.log'))
+        elif argument == "-d":
+            logger = logging.getLogger()
+            logger.setLevel(logging.DEBUG)
 
     filename_source = str(sys.argv[1])
 


### PR DESCRIPTION
As requested in https://github.com/gman-php/WoT-Battle-Results-To-JSON/pull/2 , I have added a debug mode (activated with -d flag) and switched the checksum mismatch errors to only being output in debug mode.

Additionally, in or out of debug mode, checksum mismatch errors will no longer stop the program from running, instead None will be returned if there is a checksum mismatch. This matches the behavior before I added the logging for the mismatch errors in the first place.